### PR TITLE
Landscape Tuning

### DIFF
--- a/potts_model.py
+++ b/potts_model.py
@@ -16,7 +16,7 @@
 """Potts models derived from direct coupling analysis (DCA)."""
 
 import functools
-from typing import Optional, Sequence
+from typing import Sequence
 
 import numpy as np
 
@@ -176,9 +176,9 @@ class PottsModel:
   """
 
   def __init__(self,
-               weight_matrix,
-               field_vec,
-               wt_seq,
+               weight_matrix: np.ndarray,
+               field_vec: np.ndarray,
+               wt_seq: Sequence[int],
                coupling_scale = 1.0,
                field_scale = 1.0,
                single_mut_offset = 0.0,
@@ -233,7 +233,7 @@ class PottsModel:
     self._wt_seq = self._wt_seq[self._start_idx:self._end_idx]
 
     # One-hot representation for downstream calculations.
-    self._wt_onehot_seq = utils.onehot([self._wt_seq], num_classes=self._vocab_size)[0, :, :]
+    self._wt_onehot_seq = utils.onehot([self._wt_seq], num_classes=self._vocab_size)[0]
 
     # Modify field terms for offsets
     self._field_vec = _get_shifted_fields(self._field_vec, single_mut_offset,

--- a/tuning.py
+++ b/tuning.py
@@ -1,0 +1,308 @@
+# coding=utf-8
+# Copyright 2021 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Landscape tuning."""
+
+import itertools
+from pprint import pprint
+from typing import Optional, Tuple, Dict
+
+import pandas as pd
+import numpy as np
+from scipy.special import comb
+
+import potts_model
+import sampling
+import experiment
+import utils
+
+
+def get_fraction_adaptive_singles(landscape: potts_model.PottsModel) -> float:
+    """Returns the fraction of singles that are adaptive."""
+    all_singles = sampling.get_all_single_mutants(landscape.wildtype_sequence, landscape.vocab_size)
+    wt_fitness = landscape.evaluate(landscape.wildtype_sequence).item()
+    fraction_adaptive = (landscape.evaluate(all_singles) >= wt_fitness).sum() / all_singles.shape[0]
+    return fraction_adaptive
+
+
+def get_doubles_df(landscape: potts_model.PottsModel, threshold: float, adaptive: bool) -> pd.DataFrame:
+    """Returns a DataFrame of all combinations of singles that are above/below a given fitness threshold.
+
+    For each double mutant, the DataFrame includes the keys:
+        'fitness': the fitness of the double.
+        'a_fitness': the fitness of the first constituent single.
+        'b_fitness': the fitness of the second constituent single.
+        'residual': the epistatic term ].
+    """
+    wt_seq = landscape.wildtype_sequence
+    all_singles = sampling.get_all_single_mutants(wt_seq, landscape.vocab_size)
+    df = experiment.get_fitness_df(all_singles, landscape.evaluate, wt_seq)
+    if adaptive:
+        singles = df[df.fitness >= threshold].sequence
+    else:
+        singles = df[df.fitness < threshold].sequence
+
+    if len(singles) < 2:
+        raise ValueError(f'Invalid Landscape: fewer than 2 singles for threshold {threshold}')
+
+    doubles = []
+    single_a = []
+    single_b = []
+    for a, b in itertools.combinations(singles, 2):
+        # check that this is a true double
+        if utils.get_mutation_positions(a, wt_seq) == utils.get_mutation_positions(b, wt_seq):
+            continue
+        double = utils.add_seqs(a, b, wt_seq)[0]
+        doubles.append(double)
+        single_a.append(a)
+        single_b.append(b)
+
+    doubles_df = experiment.get_fitness_df(doubles, landscape.evaluate, wt_seq)
+
+    single_a_fitness = landscape.evaluate(np.vstack(single_a))
+    single_b_fitness = landscape.evaluate(np.vstack(single_b))
+    doubles_df['a_fitness'] = single_a_fitness
+    doubles_df['b_fitness'] = single_b_fitness
+
+    residual = doubles_df.fitness - doubles_df.a_fitness - doubles_df.b_fitness + landscape.evaluate(wt_seq)
+    doubles_df['residual'] = residual
+    return doubles_df
+
+
+def get_epistasis_stats(landscape: potts_model.PottsModel,
+                        threshold: float = 0, adaptive: bool = True) -> Tuple[float, float]:
+    """Returns statistics about epistasis for combinations of singles.
+
+    Mean epistasis effect size is defined as the average effect of epistasis when two single mutants
+    from the selected set are combined. The rate of reciprocal sign epistasis is defined as the fraction
+    of epistatic interactions that have effects opposing the effects of the constituent singles. (i.e. the rate
+    of negative epistasis for adaptive singles in combination).
+
+    Args:
+      landscape: The landscape.
+      threshold: The threshold fitness for singles.
+      adaptive: If True, thresholded singles will have fitness >= `threshold`. If False,
+        selected singles will have fitness < `threshold`.
+
+    Returns:
+      A Tuple of length 2 where element [0] is the mean epistasis effect size
+      and element [1] is the rate of reciprocal sign epistasis.
+    """
+    doubles_df = get_doubles_df(landscape, threshold, adaptive)
+    residual = doubles_df.residual
+
+    mean_epistasis_effect = np.mean(residual)
+    if adaptive:
+        rate_reciprocal_epistasis = (residual < 0).sum() / residual.shape[0]
+    else:
+        rate_reciprocal_epistasis = (residual > 0).sum() / residual.shape[0]
+    return mean_epistasis_effect, rate_reciprocal_epistasis
+
+
+def get_mean_single_effect(landscape: potts_model.PottsModel, threshold: float = 0, adaptive: bool = True) -> float:
+    """Returns average effect size of singles for a given threshold.
+
+    Args:
+      landscape: The landscape.
+      threshold: The threshold fitness for singles.
+      adaptive: If True, thresholded singles will have fitness >= `threshold`. If False,
+        selected singles will have fitness < `threshold`.
+
+    Returns:
+      The average effect size of the selected singles.
+    """
+    all_singles = sampling.get_all_single_mutants(landscape.wildtype_sequence, landscape.vocab_size)
+    df = experiment.get_fitness_df(all_singles, landscape.evaluate, landscape.wildtype_sequence)
+    if adaptive:
+        mean_single_effect = df[df.fitness >= threshold].fitness.mean()
+    else:
+        mean_single_effect = df[df.fitness < threshold].fitness.mean()
+    return mean_single_effect
+
+
+def get_epistatic_horizon(landscape: potts_model.PottsModel) -> float:
+    r"""Returns the epistatic horizon for the given landscape.
+
+    The "epistatic horizon" is defined as the distance K from the wildtype at which, on average,
+    epistatic contributions outweigh linear contributions from adaptive singles. This is the average
+    distance we can expect a greedy algorithm to perform well on the given landscape.
+
+    Let $s_+$ be the average adaptive single mutant effect. let $e_{+,+}$ be the average
+    epistatic effect for a pair of adaptive singles. Then K is defined as :
+
+    $$
+    K * s_+ + (K \\choose 2) e_{+,+} = 0
+    $$
+
+    Solving for K
+    $$
+    K = \\dfrac{e_{+,+} - 2 s_+}
+               {e_{+,+}}
+    $$
+
+    Returns:
+      The epistatic horizon.
+    """
+    mean_adaptive_epistasis, _ = get_epistasis_stats(landscape, threshold=0.0, adaptive=True)
+    mean_adaptive_single = get_mean_single_effect(landscape, threshold=0, adaptive=True)
+    epistatic_horizon = (mean_adaptive_epistasis - 2 * mean_adaptive_single) / mean_adaptive_epistasis
+    return epistatic_horizon
+
+
+def get_single_std(landscape: potts_model.PottsModel) -> float:
+    """Returns the standard deviation of single mutant effects."""
+    all_singles = sampling.get_all_single_mutants(landscape.wildtype_sequence, landscape.vocab_size)
+    return np.std(landscape.evaluate(all_singles))
+
+
+def get_landscape_stats(landscape: potts_model.PottsModel) -> dict:
+    """Returns a dictionary of landscape statistics."""
+    reciprocal_adaptive_epistasis_effect, fraction_reciprocal_adaptive_epistasis = get_epistasis_stats(
+        landscape, threshold=0.0, adaptive=True)
+    stats_dict = {'fraction_adaptive_singles': get_fraction_adaptive_singles(landscape),
+                  'reciprocal_adaptive_epistasis_effect': reciprocal_adaptive_epistasis_effect,
+                  'fraction_reciprocal_adaptive_epistasis': fraction_reciprocal_adaptive_epistasis,
+                  'epistatic_horizon': get_epistatic_horizon(landscape),
+                  'std_singles': get_single_std(landscape)}
+    return stats_dict
+
+
+def get_normalizing_field_scale(landscape: potts_model.PottsModel) -> float:
+    """Returns the field scale tuning parameter to normalize the spread of single mutant fitness."""
+    std_singles = get_single_std(landscape)
+    return 1.0 / std_singles
+
+
+def get_single_mut_offset(landscape: potts_model.PottsModel, fraction_adaptive_singles: float) -> float:
+    """Returns the single mutant offset tuning parameter to achieve `fraction_adaptive_singles`."""
+    all_singles = sampling.get_all_single_mutants(landscape.wildtype_sequence, landscape.vocab_size)
+    single_fitness = landscape.evaluate(all_singles)
+    single_mut_offset = -1 * np.quantile(single_fitness, q=1 - fraction_adaptive_singles)
+    # np.quantile returns float64 by default
+    return single_mut_offset.astype(np.float32)
+
+
+def get_epi_offset(landscape: potts_model.PottsModel,
+                   fraction_reciprocal_adaptive_epistasis: float,
+                   single_mut_offset: float = 0.0) -> float:
+    """Returns the epistatic offset tuning parameter to achieve `fraction_reciprocal_adaptive_epistasis`.
+
+    # TODO(nthomas) add note about pretuning the landscape
+    """
+    # single mutant offset changes the set of adaptive singles
+    pretuned_landscape = potts_model.PottsModel(landscape.weight_matrix,
+                                                landscape.field_vec,
+                                                landscape.wildtype_sequence,
+                                                single_mut_offset=single_mut_offset)
+    doubles_df = get_doubles_df(pretuned_landscape, threshold=0.0, adaptive=True)
+    # we want fraction to remain negative
+    epi_offset = -1 * np.quantile(doubles_df.residual, q=fraction_reciprocal_adaptive_epistasis)
+    # np.quantile returns float64 by default
+    return epi_offset.astype(np.float32)
+
+
+def get_coupling_scale(landscape: potts_model.PottsModel,
+                       epistatic_horizon: float,
+                       field_scale: float = 1.0,
+                       single_mut_offset: float = 0.0,
+                       epi_offset: float = 0.0) -> float:
+    """Returns the coupling scale tuning parameter to achieve `epistatic_horizon`.
+
+    The epistatic horizon depends on other landscape statistics.
+    Let $s_+$ be the average adaptive single mutant effect.
+    Let $e_{+,+}$ be the average epistatic effect for a pair of adaptive singles.
+    Then, given K, we solve the following equation to determine the coupling-scale:
+
+    $$K * field_scale (s_+ + field-scale) + (K choose 2) * coupling-scale (e_{+,+} + epi_offset) = 0$$
+    """
+    adaptive_threshold = 0.0
+    is_adaptive = True
+
+    pretuned_landscape = potts_model.PottsModel(landscape.weight_matrix,
+                                                landscape.field_vec,
+                                                wt_seq=landscape.wildtype_sequence,
+                                                field_scale=field_scale,
+                                                single_mut_offset=single_mut_offset,
+                                                epi_offset=epi_offset)
+    mean_adaptive_single_effect = get_mean_single_effect(
+        pretuned_landscape, threshold=adaptive_threshold, adaptive=is_adaptive)
+    mean_epistasis_effect = get_doubles_df(
+        pretuned_landscape, threshold=adaptive_threshold, adaptive=is_adaptive).residual.mean()
+
+    K = epistatic_horizon
+    numerator = - K * mean_adaptive_single_effect
+    denominator = comb(K, 2) * mean_epistasis_effect
+    coupling_scale = numerator / denominator
+    return coupling_scale
+
+
+# TODO(nthomas) implement fraction_reciprocal_deleterious_epistasis:
+#   The fraction of deleterious(-, -) doubles that exhibit positive epistasis.
+def get_tuning_kwargs(landscape: potts_model.PottsModel,
+                      fraction_adaptive_singles: Optional[float] = None,
+                      fraction_reciprocal_adaptive_epistasis: Optional[float] = None,
+                      epistatic_horizon: Optional[float] = None,
+                      normalize_to_singles: bool = False) -> Dict[str, float]:
+    """Returns the landscape tuning parameters.
+
+    Args:
+      landscape: A landscape.
+      fraction_adaptive_singles: The fraction of singles that achieve a fitness > wildtype. If unset,
+        this fraction is preserved in the initial landscape
+      fraction_reciprocal_adaptive_epistasis: The fraction of adaptive (+, +) doubles that exhibit negative
+        epistasis.
+      epistatic_horizon: average distance at which epi effects out weigh singles
+      normalize_to_singles: A boolean, when True, ensures that the standard deviation of single mutant effects
+        is 1.0.
+
+    Returns:
+      A dict of tuning parameters
+      A tuple of [shift, shift, scale, scale] tuning parameters.
+    """
+    # default tuning params
+    coupling_scale = 1.0
+    field_scale = 1.0
+    single_mut_offset = 0.0
+    epi_offset = 0.0
+
+    print('Untuned landscape stats:')
+    pprint(get_landscape_stats(landscape))
+
+    # compute tuning parameters
+    if normalize_to_singles is not None:
+        field_scale = get_normalizing_field_scale(landscape)
+
+    if fraction_adaptive_singles is not None:
+        if not (fraction_adaptive_singles >= 0 and fraction_adaptive_singles <= 1.0):
+            raise ValueError(f'Invalid fraction: {fraction_adaptive_singles} must be between 0 and 1.')
+        single_mut_offset = get_single_mut_offset(landscape, fraction_adaptive_singles)
+
+    if fraction_reciprocal_adaptive_epistasis is not None:
+        if not (fraction_reciprocal_adaptive_epistasis >= 0 and fraction_reciprocal_adaptive_epistasis <= 1.0):
+            raise ValueError(f'Invalid fraction: {fraction_reciprocal_adaptive_epistasis} must be between 0 and 1.')
+        epi_offset = get_epi_offset(landscape,
+                                    fraction_reciprocal_adaptive_epistasis,
+                                    single_mut_offset=single_mut_offset)
+
+    if epistatic_horizon:
+        if not (epistatic_horizon >= 0):
+            raise ValueError(f'Invalid fraction: {epistatic_horizon} must be greater than 0.')
+        coupling_scale = get_coupling_scale(landscape, epistatic_horizon, field_scale, single_mut_offset, epi_offset)
+
+    tuning_kwargs = {'coupling_scale': coupling_scale,
+                     'field_scale': field_scale,
+                     'single_mut_offset': single_mut_offset,
+                     'epi_offset': epi_offset}
+    return tuning_kwargs

--- a/tuning.py
+++ b/tuning.py
@@ -29,22 +29,22 @@ import experiment
 import utils
 
 
-def get_fraction_adaptive_singles(landscape: potts_model.PottsModel) -> float:
-    """Returns the fraction of singles that are adaptive."""
+def get_adaptive_single_fraction(landscape: potts_model.PottsModel) -> float:
+    """Returns the fraction of single mutants with fitness >= to the wildtype fitness."""
     all_singles = sampling.get_all_single_mutants(landscape.wildtype_sequence, landscape.vocab_size)
     wt_fitness = landscape.evaluate(landscape.wildtype_sequence).item()
-    fraction_adaptive = (landscape.evaluate(all_singles) >= wt_fitness).sum() / all_singles.shape[0]
+    fraction_adaptive = (landscape.evaluate(all_singles) >= wt_fitness).mean()
     return fraction_adaptive
 
 
 def get_doubles_df(landscape: potts_model.PottsModel, threshold: float, adaptive: bool) -> pd.DataFrame:
-    """Returns a DataFrame of all pairwise combinations of singles above/below a given fitness threshold.
+    """Returns a DataFrame of all pairwise combinations of singles, where the singles are above/below a given fitness threshold.
 
-    For each double mutant, the DataFrame includes the keys:
+    For each double mutant, the DataFrame includes the columns:
         'fitness': the fitness of the double.
         'a_fitness': the fitness of the first constituent single.
         'b_fitness': the fitness of the second constituent single.
-        'residual': the epistatic term ].
+        'residual': the epistatic term: fitness(ab) - fitness(a) - fitness(b) + fitness(wt).
 
     Args:
         landscape: The landscape on which to compute double fitness.
@@ -90,29 +90,33 @@ def get_doubles_df(landscape: potts_model.PottsModel, threshold: float, adaptive
     return doubles_df
 
 
-def get_epistasis_stats(landscape: potts_model.PottsModel,
-                        threshold: float = 0, adaptive: bool = True) -> Tuple[float, float]:
+def get_epistasis_stats(landscape: potts_model.PottsModel, doubles_df: pd.DataFrame) -> Tuple[float, float]:
     """Returns statistics about epistasis for combinations of singles.
 
     Mean epistasis effect size is defined as the average effect of epistasis when two single mutants
     from the selected set are combined. The rate of reciprocal sign epistasis is defined as the fraction
-    of epistatic interactions that have effects opposing the effects of the constituent singles. (i.e. the rate
+    of epistatic interactions that have effects opposing the effects of the constituent singles. (e.g. the rate
     of negative epistasis for adaptive singles in combination).
 
     Args:
       landscape: The landscape.
-      threshold: The threshold fitness for selected singles.
-      adaptive: If True, thresholded singles will have fitness >= `threshold`. If False,
-        selected singles will have fitness < `threshold`.
+      doubles_df: A DataFrame consisting of double mutants to compute epistasis statistic son.
 
     Returns:
-      A Tuple of length 2 where element [0] is the mean epistasis effect size
-      and element [1] is the rate of reciprocal sign epistasis.
+        mean_epistasis_effect: The average effect of epistasis when two single mutants from the selected set are combined.
+        rate_reciprocal_sign_epistasis: The fraction of epistatic interactions that have opposite effects to the constituent singles.
     """
-    doubles_df = get_doubles_df(landscape, threshold, adaptive)
     residual = doubles_df.residual
+    threshold = landscape.evaluate(landscape.wildtype_sequence).item()
 
     mean_epistasis_effect = np.mean(residual)
+    if (doubles_df.a_fitness >= threshold).all() and (doubles_df.b_fitness >= threshold).all():
+        adaptive = True
+    elif (doubles_df.a_fitness < threshold).all() and (doubles_df.b_fitness < threshold).all():
+        adaptive = False
+    else:
+        raise ValueError('Reciprocal sign epistasis undefined for inconsistent doubles effects.')
+
     if adaptive:
         rate_reciprocal_epistasis = (residual < 0).sum() / residual.shape[0]
     else:
@@ -120,7 +124,7 @@ def get_epistasis_stats(landscape: potts_model.PottsModel,
     return mean_epistasis_effect, rate_reciprocal_epistasis
 
 
-def get_mean_single_effect(landscape: potts_model.PottsModel, threshold: float = 0, adaptive: bool = True) -> float:
+def get_mean_single_effect(landscape: potts_model.PottsModel, threshold: float, adaptive: bool) -> float:
     """Returns average effect size of singles for a given threshold.
 
     Args:
@@ -145,17 +149,18 @@ def get_epistatic_horizon(landscape: potts_model.PottsModel) -> float:
     r"""Returns the epistatic horizon for the given landscape.
 
     The "epistatic horizon" is defined as the distance K from the wildtype at which, on average,
-    epistatic contributions outweigh linear contributions from adaptive singles. This is the average
-    distance we can expect a greedy algorithm to perform well on the given landscape.
+    epistatic contributions outweigh linear contributions from adaptive singles. This is interpreted as
+    the average distance we can expect a greedy algorithm to perform well on the given landscape.
 
-    Let $s_+$ be the average adaptive single mutant effect. let $e_{+,+}$ be the average
+    Let s_+ be the average adaptive single mutant effect. let e_{+,+} be the average
     epistatic effect for a pair of adaptive singles. Then K is defined as :
 
     $$
     K * s_+ + (K \\choose 2) e_{+,+} = 0
     $$
 
-    Solving for K
+    Solving for K:
+
     $$
     K = \\dfrac{e_{+,+} - 2 s_+}
                {e_{+,+}}
@@ -164,9 +169,13 @@ def get_epistatic_horizon(landscape: potts_model.PottsModel) -> float:
     Returns:
       The epistatic horizon.
     """
-    mean_adaptive_epistasis, _ = get_epistasis_stats(landscape, threshold=0.0, adaptive=True)
+    doubles_df = get_doubles_df(landscape, threshold=0.0, adaptive=True)
+    mean_adaptive_epistasis, _ = get_epistasis_stats(landscape, doubles_df)
     mean_adaptive_single = get_mean_single_effect(landscape, threshold=0, adaptive=True)
-    epistatic_horizon = (mean_adaptive_epistasis - 2 * mean_adaptive_single) / mean_adaptive_epistasis
+    if mean_adaptive_epistasis == 0.0:
+        epistatic_horizon = np.inf
+    else:
+        epistatic_horizon = (mean_adaptive_epistasis - 2 * mean_adaptive_single) / mean_adaptive_epistasis
     return epistatic_horizon
 
 
@@ -178,9 +187,10 @@ def get_single_std(landscape: potts_model.PottsModel) -> float:
 
 def get_landscape_stats(landscape: potts_model.PottsModel) -> dict:
     """Returns a dictionary of landscape statistics."""
+    adaptive_doubles_df = get_doubles_df(landscape, threshold=0.0, adaptive=True)
     reciprocal_adaptive_epistasis_effect, fraction_reciprocal_adaptive_epistasis = get_epistasis_stats(
-        landscape, threshold=0.0, adaptive=True)
-    stats_dict = {'fraction_adaptive_singles': get_fraction_adaptive_singles(landscape),
+        landscape, adaptive_doubles_df)
+    stats_dict = {'fraction_adaptive_singles': get_adaptive_single_fraction(landscape),
                   'reciprocal_adaptive_epistasis_effect': reciprocal_adaptive_epistasis_effect,
                   'fraction_reciprocal_adaptive_epistasis': fraction_reciprocal_adaptive_epistasis,
                   'epistatic_horizon': get_epistatic_horizon(landscape),
@@ -224,9 +234,9 @@ def get_epi_offset(landscape: potts_model.PottsModel,
 
 def get_coupling_scale(landscape: potts_model.PottsModel,
                        epistatic_horizon: float,
-                       field_scale: float = 1.0,
-                       single_mut_offset: float = 0.0,
-                       epi_offset: float = 0.0) -> float:
+                       field_scale: float,
+                       single_mut_offset: float,
+                       epi_offset: float) -> float:
     """Returns the coupling scale tuning parameter to achieve `epistatic_horizon`.
 
     The epistatic horizon depends on other landscape statistics.
@@ -236,6 +246,8 @@ def get_coupling_scale(landscape: potts_model.PottsModel,
 
     $$K * field_scale (s_+ + field-scale) + (K choose 2) * coupling-scale (e_{+,+} + epi_offset) = 0$$
     """
+    if epistatic_horizon < 0:
+        raise ValueError('Epistatic horizon must be positive.')
     adaptive_threshold = 0.0
     is_adaptive = True
 
@@ -257,8 +269,6 @@ def get_coupling_scale(landscape: potts_model.PottsModel,
     return coupling_scale
 
 
-# TODO(nthomas) implement fraction_reciprocal_deleterious_epistasis:
-#   The fraction of deleterious(-, -) doubles that exhibit positive epistasis.
 def get_tuning_kwargs(landscape: potts_model.PottsModel,
                       fraction_adaptive_singles: Optional[float] = None,
                       fraction_reciprocal_adaptive_epistasis: Optional[float] = None,
@@ -266,37 +276,39 @@ def get_tuning_kwargs(landscape: potts_model.PottsModel,
                       normalize_to_singles: bool = False) -> Dict[str, float]:
     """Returns the landscape tuning parameters.
 
+    Each tuning argument is optional. If `None` is passed to a floating point argument,
+    or `False` is passed to a boolean argument, the returned tuning parameter dict will not tune that property.
+
     Args:
       landscape: A landscape.
       fraction_adaptive_singles: The fraction of singles that achieve a fitness > wildtype. If unset,
-        this fraction is preserved in the initial landscape
+        this fraction is preserved in the initial landscape.
       fraction_reciprocal_adaptive_epistasis: The fraction of adaptive (+, +) doubles that exhibit negative
         epistasis.
-      epistatic_horizon: average distance at which epi effects out weigh singles
+      epistatic_horizon: The average distance at which epistatic effects outweigh single effects.
       normalize_to_singles: A boolean, when True, ensures that the standard deviation of single mutant effects
         is 1.0.
 
     Returns:
-      A dict of tuning parameters
-      A tuple of [shift, shift, scale, scale] tuning parameters.
+      A dict of named tuning arguments to the potts_model.PottsModel constructor.
     """
     # default tuning params
-    coupling_scale = 1.0
-    field_scale = 1.0
-    single_mut_offset = 0.0
-    epi_offset = 0.0
 
     print('Untuned landscape stats:')
     pprint(get_landscape_stats(landscape))
 
     # compute tuning parameters
-    if normalize_to_singles is not None:
+    if normalize_to_singles:
         field_scale = get_normalizing_field_scale(landscape)
+    else:
+        field_scale = 1.0
 
     if fraction_adaptive_singles is not None:
         if not (fraction_adaptive_singles >= 0 and fraction_adaptive_singles <= 1.0):
             raise ValueError(f'Invalid fraction: {fraction_adaptive_singles} must be between 0 and 1.')
         single_mut_offset = get_single_mut_offset(landscape, fraction_adaptive_singles)
+    else:
+        single_mut_offset = 0.0
 
     if fraction_reciprocal_adaptive_epistasis is not None:
         if not (fraction_reciprocal_adaptive_epistasis >= 0 and fraction_reciprocal_adaptive_epistasis <= 1.0):
@@ -304,11 +316,15 @@ def get_tuning_kwargs(landscape: potts_model.PottsModel,
         epi_offset = get_epi_offset(landscape,
                                     fraction_reciprocal_adaptive_epistasis,
                                     single_mut_offset=single_mut_offset)
+    else:
+        epi_offset = 0.0
 
     if epistatic_horizon:
         if not (epistatic_horizon >= 0):
             raise ValueError(f'Invalid fraction: {epistatic_horizon} must be greater than 0.')
         coupling_scale = get_coupling_scale(landscape, epistatic_horizon, field_scale, single_mut_offset, epi_offset)
+    else:
+        coupling_scale = 1.0
 
     tuning_kwargs = {'coupling_scale': coupling_scale,
                      'field_scale': field_scale,

--- a/tuning.py
+++ b/tuning.py
@@ -38,13 +38,22 @@ def get_fraction_adaptive_singles(landscape: potts_model.PottsModel) -> float:
 
 
 def get_doubles_df(landscape: potts_model.PottsModel, threshold: float, adaptive: bool) -> pd.DataFrame:
-    """Returns a DataFrame of all combinations of singles that are above/below a given fitness threshold.
+    """Returns a DataFrame of all pairwise combinations of singles above/below a given fitness threshold.
 
     For each double mutant, the DataFrame includes the keys:
         'fitness': the fitness of the double.
         'a_fitness': the fitness of the first constituent single.
         'b_fitness': the fitness of the second constituent single.
         'residual': the epistatic term ].
+
+    Args:
+        landscape: The landscape on which to compute double fitness.
+        threshold: The threshold fitness for filtering single mutants.
+        adaptive: A boolean, indicating, if True (False), to construct pairwise combinations from single mutants
+            that are above (below) the `threshold` fitness.
+
+    Returns:
+        A DataFrame of double mutants with keys 'fitness', 'a_fitness', 'b_fitness', and 'residual'.
     """
     wt_seq = landscape.wildtype_sequence
     all_singles = sampling.get_all_single_mutants(wt_seq, landscape.vocab_size)
@@ -92,7 +101,7 @@ def get_epistasis_stats(landscape: potts_model.PottsModel,
 
     Args:
       landscape: The landscape.
-      threshold: The threshold fitness for singles.
+      threshold: The threshold fitness for selected singles.
       adaptive: If True, thresholded singles will have fitness >= `threshold`. If False,
         selected singles will have fitness < `threshold`.
 

--- a/tuning_test.py
+++ b/tuning_test.py
@@ -1,0 +1,266 @@
+# coding=utf-8
+# Copyright 2021 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for synthetic_protein_landscapes.tuning."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import numpy as np
+from scipy.special import comb
+
+import tuning
+import potts_model
+import sampling
+
+
+class TuningParamsTest(parameterized.TestCase):
+    """Test class for tuning."""
+
+    def _get_params(self, seed):
+        """Weight matrix and field vector."""
+        rng = np.random.default_rng(seed)
+        weight_matrix = rng.standard_normal(size=(4, 4, 20, 20), dtype=np.float32)
+        # make symmetric
+        weight_matrix = weight_matrix + np.moveaxis(weight_matrix, (0, 1, 2, 3), (1, 0, 3, 2))
+        field_vec = rng.standard_normal(size=(4, 20), dtype=np.float32)
+        return weight_matrix, field_vec
+
+    def _get_landscape(self, seed, wt_seq=[0, 0, 0, 0], **kwargs):
+        """Return a small PottsModel landscape."""
+        weight_matrix, field_vec = self._get_params(seed)
+        return potts_model.PottsModel(weight_matrix, field_vec, wt_seq=wt_seq, **kwargs)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='wt_0',
+            seed=0,
+            wt_seq=[0, 0, 0, 0],
+        ),
+        dict(
+            testcase_name='wt_1',
+            seed=1,
+            wt_seq=[1, 1, 1, 1],
+        ),
+    )
+    def test_normalize_to_singles(self, wt_seq, seed):
+        untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
+        tuning_kwargs = tuning.get_tuning_kwargs(untuned_landscape, normalize_to_singles=True)
+        tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
+
+        all_single_fitness = tuned_landscape.evaluate(
+            sampling.get_all_single_mutants(wt_seq, tuned_landscape.vocab_size))
+        np.testing.assert_allclose(np.std(all_single_fitness), 1.0, rtol=1e-6)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='adaptive_70',
+            seed=1,
+            wt_seq=[0, 0, 0, 0],
+            fraction_adaptive_singles=0.7,
+        ),
+        dict(
+            testcase_name='adaptive_10',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            fraction_adaptive_singles=0.1,
+        ),
+        dict(
+            testcase_name='adaptive_100',
+            seed=3,
+            wt_seq=[1, 1, 1, 1],
+            fraction_adaptive_singles=1.0,
+        ),
+        dict(
+            testcase_name='adaptive_0',
+            seed=4,
+            wt_seq=[1, 1, 1, 1],
+            fraction_adaptive_singles=0.0,
+        ),
+    )
+    def test_tune_fraction_adaptive_singles(self, wt_seq, seed, fraction_adaptive_singles):
+        untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
+
+        tuning_kwargs = tuning.get_tuning_kwargs(
+            untuned_landscape,
+            fraction_adaptive_singles=fraction_adaptive_singles)
+
+        tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
+        actual_fraction_adaptive_singles = tuning.get_fraction_adaptive_singles(tuned_landscape)
+
+        num_singles = len(wt_seq) * (untuned_landscape.vocab_size - 1)
+        # Because we adjust single mutant fitness, we can only get to within
+        # 1 / num_singles of the desired proportion.
+        allowed_error = 1.0 / num_singles
+        self.assertBetween(actual_fraction_adaptive_singles,
+                           fraction_adaptive_singles - allowed_error,
+                           fraction_adaptive_singles + allowed_error)
+
+    def test_no_adaptives_raises(self):
+        wt_seq = [0, 0, 0, 0]
+        weight_matrix = np.zeros(shape=(4, 4, 20, 20), dtype=np.float32)
+        import utils
+        field_vec = np.zeros(shape=(4, 20), dtype=np.float32) - utils.onehot(wt_seq, num_classes=20)
+        dead_landscape = potts_model.PottsModel(weight_matrix, field_vec, wt_seq=wt_seq)
+
+        with self.assertRaisesRegex(ValueError, 'Invalid Landscape'):
+            tuning.get_doubles_df(dead_landscape, threshold=0, adaptive=True)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='reciprocal_10',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            desired_fraction=0.1,
+        ),
+        dict(
+            testcase_name='reciprocal_90',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            desired_fraction=0.9,
+        ),
+        dict(
+            testcase_name='reciprocal_50',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            desired_fraction=0.5,
+        ),
+        dict(
+            testcase_name='reciprocal_66',
+            seed=3,
+            wt_seq=[1, 1, 1, 1],
+            desired_fraction=0.66,
+        ),
+    )
+    def test_tune_epistasis(self, wt_seq, seed, desired_fraction):
+        untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
+        untuned_fraction_adaptive_singles = tuning.get_fraction_adaptive_singles(untuned_landscape)
+
+        tuning_kwargs = tuning.get_tuning_kwargs(
+            untuned_landscape,
+            fraction_reciprocal_adaptive_epistasis=desired_fraction)
+
+        tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
+        _, actual_fraction = tuning.get_epistasis_stats(tuned_landscape)
+
+        num_singles = len(wt_seq) * (untuned_landscape.vocab_size - 1)
+        num_adaptive_singles = num_singles * untuned_fraction_adaptive_singles
+
+        # This error bound is only exact if all adaptive singles affect unique positions,
+        # otherwise it is more restrictive than necessary.
+        num_adaptive_doubles = comb(num_adaptive_singles, 2)
+        allowed_error = 1.0 / num_adaptive_doubles
+
+        self.assertBetween(actual_fraction,
+                           desired_fraction - allowed_error,
+                           desired_fraction + allowed_error)
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='horizon_2',
+            seed=0,
+            wt_seq=[0, 0, 0, 0],
+            desired_horizon=2,
+        ),
+        dict(
+            testcase_name='horizon_5',
+            seed=1,
+            wt_seq=[0, 0, 0, 0],
+            desired_horizon=5,
+        ),
+        dict(
+            testcase_name='horizon_10',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            desired_horizon=10,
+        ),
+        dict(
+            testcase_name='horizon_100',
+            seed=3,
+            wt_seq=[1, 1, 1, 1],
+            desired_horizon=100,
+        ),
+    )
+    def test_tune_epistatic_horizon(self, wt_seq, seed, desired_horizon):
+        untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
+
+        tuning_kwargs = tuning.get_tuning_kwargs(
+            untuned_landscape,
+            epistatic_horizon=desired_horizon)
+
+        tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
+
+        actual_horizon = tuning.get_epistatic_horizon(tuned_landscape)
+        # TODO(nthomas) make this exact.
+        self.assertAlmostEqual(desired_horizon, actual_horizon, places=3)
+
+# TODO(nthomas) add test for singles and epi offset to act independently...
+
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='tuning_0',
+            seed=2,
+            wt_seq=[0, 0, 0, 0],
+            desired_stats_dict={'fraction_adaptive_singles': 0.7,
+                                'fraction_reciprocal_adaptive_epistasis': 0.5,
+                                'epistatic_horizon': 10}
+        ),
+        dict(
+            testcase_name='tuning_1',
+            seed=3,
+            wt_seq=[1, 1, 1, 1],
+            desired_stats_dict={'fraction_adaptive_singles': 0.2,
+                                'fraction_reciprocal_adaptive_epistasis': 0.66,
+                                'epistatic_horizon': 20},
+        ),
+    )
+    def test_tuned_stats(self, wt_seq, seed, desired_stats_dict):
+        untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
+
+        tuning_kwargs = tuning.get_tuning_kwargs(
+            untuned_landscape,
+            normalize_to_singles=True,
+            fraction_adaptive_singles=desired_stats_dict['fraction_adaptive_singles'],
+            fraction_reciprocal_adaptive_epistasis=desired_stats_dict['fraction_reciprocal_adaptive_epistasis'],
+            epistatic_horizon=desired_stats_dict['epistatic_horizon'])
+
+        tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
+        actual_stats_dict = tuning.get_landscape_stats(tuned_landscape)
+
+        num_singles = len(wt_seq) * (untuned_landscape.vocab_size - 1)
+        # Because we are adjusting quantiles, we can only get to within
+        # 1 / num_singles of the desired proportion
+        max_singles_proportion_error = 1.0 / num_singles
+        self.assertBetween(actual_stats_dict['fraction_adaptive_singles'],
+                           desired_stats_dict['fraction_adaptive_singles'] - max_singles_proportion_error,
+                           desired_stats_dict['fraction_adaptive_singles'] + max_singles_proportion_error)
+
+        untuned_fraction_adaptive_singles = tuning.get_landscape_stats(untuned_landscape)['fraction_adaptive_singles']
+        num_adaptive_singles = num_singles * untuned_fraction_adaptive_singles
+
+        num_adaptive_doubles = comb(num_adaptive_singles, 2)
+        # TODO(nthomas) explain that we assume double collisions for safety
+        fudge_factor = 2 * (1.0 / num_adaptive_doubles)
+        self.assertBetween(actual_stats_dict['fraction_reciprocal_adaptive_epistasis'],
+                           desired_stats_dict['fraction_reciprocal_adaptive_epistasis'] - fudge_factor,
+                           desired_stats_dict['fraction_reciprocal_adaptive_epistasis'] + fudge_factor)
+
+        self.assertAlmostEqual(desired_stats_dict['epistatic_horizon'],
+                               actual_stats_dict['epistatic_horizon'],
+                               places=3)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/tuning_test.py
+++ b/tuning_test.py
@@ -98,7 +98,7 @@ class TuningParamsTest(parameterized.TestCase):
             fraction_adaptive_singles=fraction_adaptive_singles)
 
         tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
-        actual_fraction_adaptive_singles = tuning.get_fraction_adaptive_singles(tuned_landscape)
+        actual_fraction_adaptive_singles = tuning.get_adaptive_single_fraction(tuned_landscape)
 
         num_singles = len(wt_seq) * (untuned_landscape.vocab_size - 1)
         # Because we adjust single mutant fitness, we can only get to within
@@ -146,14 +146,15 @@ class TuningParamsTest(parameterized.TestCase):
     )
     def test_tune_epistasis(self, wt_seq, seed, desired_fraction):
         untuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed)
-        untuned_fraction_adaptive_singles = tuning.get_fraction_adaptive_singles(untuned_landscape)
+        untuned_fraction_adaptive_singles = tuning.get_adaptive_single_fraction(untuned_landscape)
 
         tuning_kwargs = tuning.get_tuning_kwargs(
             untuned_landscape,
             fraction_reciprocal_adaptive_epistasis=desired_fraction)
 
         tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
-        _, actual_fraction = tuning.get_epistasis_stats(tuned_landscape)
+        doubles_df = tuning.get_doubles_df(tuned_landscape, threshold=0.0, adaptive=True)
+        _, actual_fraction = tuning.get_epistasis_stats(tuned_landscape, doubles_df)
 
         num_singles = len(wt_seq) * (untuned_landscape.vocab_size - 1)
         num_adaptive_singles = num_singles * untuned_fraction_adaptive_singles

--- a/tuning_test.py
+++ b/tuning_test.py
@@ -203,8 +203,10 @@ class TuningParamsTest(parameterized.TestCase):
 
         tuned_landscape = self._get_landscape(wt_seq=wt_seq, seed=seed, **tuning_kwargs)
 
+        # TODO(nthomas) Add direct test - sample K-mutants and show that properties are as expected.
+        # See https://github.com/google-research/slip/pull/9#discussion_r879961779
         actual_horizon = tuning.get_epistatic_horizon(tuned_landscape)
-        # TODO(nthomas) make this exact.
+        # TODO(nthomas) Can we tune the epistatic horizon exactly instead of approximately?
         self.assertAlmostEqual(desired_horizon, actual_horizon, places=3)
 
 # TODO(nthomas) add test for singles and epi offset to act independently...


### PR DESCRIPTION
This PR includes utilities for tuning landscapes so that they match expected statistics. In particular, we;


* tune the fraction of adaptive single mutants
* tune the fraction of reciprocal epistasis for adaptive doubles
* normalize the variance of single mutant fitness
* set the epistatic horizon