### PR TITLE
Add function for filtering mutation sets if they include reference mutations

### DIFF
--- a/epistasis_selection.py
+++ b/epistasis_selection.py
@@ -63,9 +63,7 @@ def filter_mutation_sets_for_reference(mutation_sets: Iterable[Tuple[Mutation, .
     """Remove any mutation sets from `mutation_sets` that include a mutation corresponding to the reference sequence."""
     filtered_mutation_sets = []
     for mutation_set in mutation_sets:
-        if any([reference_seq[pos] == aa for (pos, aa) in mutation_set]):
-            continue
-        else:
+        if all([reference_seq[pos] != aa for (pos, aa) in mutation_set]):
             filtered_mutation_sets.append(mutation_set)
     return filtered_mutation_sets
 

--- a/epistasis_selection.py
+++ b/epistasis_selection.py
@@ -16,7 +16,7 @@
 
 from collections import Counter
 import itertools
-from typing import Iterable, Tuple, List
+from typing import Iterable, List, Sequence, Tuple
 
 import numpy as np
 
@@ -56,6 +56,18 @@ def combine_k_rounds(num_rounds: int,
         all_samples.extend(
             utils.merge_multiple_mutation_sets(mutation_combination))
     return all_samples
+
+
+def filter_mutation_sets_for_reference(mutation_sets: Iterable[Tuple[Mutation, ...]],
+                                       reference_seq: Sequence[int]) -> List[Tuple[Mutation, ...]]:
+    """Remove any mutation sets from `mutation_sets` that include a mutation corresponding to the reference sequence."""
+    filtered_mutation_sets = []
+    for mutation_set in mutation_sets:
+        if any([reference_seq[pos] == aa for (pos, aa) in mutation_set]):
+            continue
+        else:
+            filtered_mutation_sets.append(mutation_set)
+    return filtered_mutation_sets
 
 
 def filter_mutation_sets_by_position(mutation_sets: Iterable[Tuple[Mutation, ...]],
@@ -121,8 +133,7 @@ def get_top_k_single_mutations(landscape: potts_model.PottsModel, adaptive: bool
                                                      landscape.evaluate,
                                                      top_n=top_k,
                                                      get_highest=adaptive)
-    mutation_sets = filter_mutation_sets_by_position(
-        mutation_sets, limit=max_reuse)
+    mutation_sets = filter_mutation_sets_by_position(mutation_sets, limit=max_reuse)
     print(f'{len(mutation_sets)} singles after filtering {top_k}')
     return mutation_sets
 
@@ -146,9 +157,9 @@ def combine_mutations_and_subset(mutation_sets: Iterable[Tuple[Mutation, ...]],
     Return:
       A List of sequences of distance `target_distance` from the `wildtype_sequence`.
     """
+    mutation_sets = filter_mutation_sets_for_reference(mutation_sets, wildtype_sequence)
     all_combined = combine_k_rounds(num_rounds, mutation_sets)
-    all_combined = [element for element in all_combined if len(
-        element) == target_distance]
+    all_combined = [element for element in all_combined if len(element) == target_distance]
 
     if len(all_combined) < n:
         raise ValueError(

--- a/epistasis_selection_test.py
+++ b/epistasis_selection_test.py
@@ -124,6 +124,33 @@ class SelectionTest(parameterized.TestCase):
             mutation_sets, limit)
         self.assertSetEqual(set(actual), set(expected_set))
 
+    @parameterized.named_parameters(
+        dict(
+            testcase_name='1_remaining',
+            mutation_sets=[((0, 0), (1, 2)),
+                           ((0, 1), (2, 1), (3, 3)),
+                           ((0, 1), )],
+            wildtype_sequence=[0, 1, 2, 3],
+            expected_set=[((0, 1), ),],
+        ),
+        dict(
+            testcase_name='no_overlap',
+            mutation_sets=[((1, 2), (2, 3)),
+                           ((3, 5), (0, 5)),
+                           ((0, 1),),
+                           ((3, 7), (2, 8), (1, 0))],
+            wildtype_sequence=[0, 1, 2, 3],
+            expected_set=[((1, 2), (2, 3)),
+                          ((3, 5), (0, 5)),
+                          ((0, 1),),
+                          ((3, 7), (2, 8), (1, 0))],
+        ),
+    )
+    def test_filter_mutation_sets_for_reference(self, mutation_sets, wildtype_sequence, expected_set):
+        actual = epistasis_selection.filter_mutation_sets_for_reference(
+            mutation_sets, wildtype_sequence)
+        self.assertSetEqual(set(actual), set(expected_set))
+
 
 class GetEpistaticSeqsIntegrationTest(parameterized.TestCase):
     """Tests for epistatic sequences."""


### PR DESCRIPTION
When constructing mutants of a certain length, we want to ensure that all mutation tuples will actually change the wildtype allele. This function ensures that mutation sets of length 4 will be 4 mutations from the wildtype.